### PR TITLE
Added option to disable the sound. Fixed crash on Spider's startup

### DIFF
--- a/Source/KlondikeView.cpp
+++ b/Source/KlondikeView.cpp
@@ -238,6 +238,14 @@ void KlondikeView::Draw(BRect rect)
 
 void KlondikeView::ReciveOptionMessage(BMessage* message) {
 	switch (message->what) {
+	case kToggleSoundMessage:
+			fSoundEnabled = !fSoundEnabled;
+			if (fToggleSoundItem->IsMarked()) {
+				fToggleSoundItem->SetMarked(false);
+			} else {
+				fToggleSoundItem->SetMarked(true);
+			}
+			break;	
 	case kCheatMessage:
 		Cheat();
 		break;
@@ -827,8 +835,9 @@ void KlondikeView::_GenerateBoard()
 	for (short i = 0; i != 24; i++) {
 		fStock[i] = solitare._PickRandomCard();
 	}
-
-	fShuffle->StartPlaying();
+	
+	if (fSoundEnabled)
+		fShuffle->StartPlaying();
 }
 
 
@@ -838,7 +847,8 @@ void KlondikeView::CheckBoard() {
 			return;
 	}
 	
-	fFanfare->StartPlaying();
+	if (fSoundEnabled)
+		fFanfare->StartPlaying();
 	
 	fMouseLock = true;
 	fWon = true;
@@ -959,6 +969,12 @@ bool KlondikeView::_MoveWasteToFoundation() {
 BMenu* KlondikeView::GetOptionMenu() {
 	BMenu* mOptions = new BMenu(B_TRANSLATE("Options"));
 	BMenuItem* menuItem;
+	fToggleSoundItem = new BMenuItem(B_TRANSLATE("Enable sound"),
+		NewSolitareOptionMessage(kToggleSoundMessage));
+	fToggleSoundItem->SetMarked(true);
+	mOptions->AddItem(fToggleSoundItem);
+	fSoundEnabled = true;
+	
 	fAutoPlayEnabledItem = new BMenuItem(B_TRANSLATE("Auto-play"),
 		NewSolitareOptionMessage(kAutoPlayEnableMessage));
 	fAutoPlayEnabledItem->SetMarked(true);

--- a/Source/KlondikeView.h
+++ b/Source/KlondikeView.h
@@ -24,6 +24,7 @@ const int32 kCheatMessage = 'Chtr';
 const int32 kAutoPlayMessage = 'Auto';
 const int32 kAutoPlayEnableMessage = 'EAut';
 const int32 kQuickAutoPlayMessage = 'QAut';
+const int32 kToggleSoundMessage = 'TSnd';
 
 #define KLONDIKE_CARDS_IN_PLAY CARDS_IN_DECK
 
@@ -85,11 +86,13 @@ private:
 
 			bool				fAutoPlayEnabled;
 			bool				fQuickAutoPlay;
+			bool				fSoundEnabled;
 			short				fDoubleClick;
 			short				fAutoPlayCountdown;
 
 			BMenuItem*		fAutoPlayEnabledItem;
 			BMenuItem*		fQuickAutoPlayItem;
+			BMenuItem*		fToggleSoundItem;
 
 			int					fPoints;
 			Solitare solitare;

--- a/Source/SolitareView.h
+++ b/Source/SolitareView.h
@@ -28,7 +28,6 @@ public:
 	virtual void Hint();
 	
 private:
-
 };
 
 

--- a/Source/SpiderView.h
+++ b/Source/SpiderView.h
@@ -23,6 +23,7 @@ const uint32 sNewGameMessage = 'NewG';
 const uint32 sDifficultyMessage = 'Diff';
 const uint32 sDiffChosenMessage = 'DiCh';
 const uint32 sHintMessage = 'Hint';
+const uint32 sToggleSoundMessage = 'TSnd';
 
 class SpiderView : public SolitareView {
 public:
@@ -81,7 +82,11 @@ private:
 
 	short fStacked;
 	short fStackedColor[8];
-
+	
+	bool		fSoundEnabled;
+	
+	BMenuItem*	fToggleSoundItem;
+	
 	int fPoints;
 	int fMoves;
 


### PR DESCRIPTION
As it is, Spider's code was crashing on startup, so I basically copied the code from Klondike's side which was working correctly. Then I just added the option to disable the sound (not permanent for the moment, but as BeSpider doesn't store any settings we still have to write that portion of code, job for another day)